### PR TITLE
fix: merge scm file into already loaded with '; extends'

### DIFF
--- a/lua/gotmpl/init.lua
+++ b/lua/gotmpl/init.lua
@@ -3,7 +3,7 @@ local M = {}
 M.setup = function()
 	vim.treesitter.query.add_directive("inject-go-tmpl!", function(_, _, bufnr, _, metadata)
 		local fname = vim.fs.basename(vim.api.nvim_buf_get_name(bufnr))
-		local _, _, ext, _ = string.find(fname, ".*%.(%a+)(%.%a+)")
+		local _, _, ext, _ = string.find(fname, ".*%.([^.]+)(%.%a+)")
 		if ext then
 			metadata["injection.language"] = ext
 		end

--- a/lua/gotmpl/init.lua
+++ b/lua/gotmpl/init.lua
@@ -14,6 +14,12 @@ M.setup = function()
 			tmpl = "gotmpl",
 		},
 	})
+  vim.api.nvim_create_autocmd("FileType", {
+		pattern = "gotmpl",
+		callback = function()
+			vim.treesitter.start()
+		end,
+	})
 end
 
 return M

--- a/queries/gotmpl/injections.scm
+++ b/queries/gotmpl/injections.scm
@@ -1,3 +1,4 @@
+; extends
 ((text) @injection.content
   (#inject-go-tmpl!)
   (#set! injection.combined))


### PR DESCRIPTION
Without `; extends` at the top of injections.scm the file is not loaded when other injection.scm for the same language is present, so no 'inside' language is highlighted. This PR fixes this behavior